### PR TITLE
Fix(example): Prevent cpal 'index out of bounds' panic in play_nsf

### DIFF
--- a/examples/play_nsf.rs
+++ b/examples/play_nsf.rs
@@ -1,29 +1,31 @@
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use cpal::SampleFormat;
 use game_music_emu::GameMusicEmu;
-use cpal::{SampleFormat};
-use cpal::traits::{HostTrait, DeviceTrait, StreamTrait};
 
 fn main() {
-    let game_music_emu = GameMusicEmu::from_file("assets/test.nsf", 44100).unwrap();
-    game_music_emu.start_track(0).unwrap();
-
     let err_fn = |err| eprintln!("an error occurred on the output audio stream: {}", err);
     let host = cpal::default_host();
     let device = host.default_output_device().unwrap();
     let config = device.default_output_config().unwrap();
-    const BUFFER_SIZE: usize = 1024;
-    let mut emu_buffer = [0 as i16; BUFFER_SIZE];
+    let sample_rate = config.sample_rate().0 as u32;
+
+    let game_music_emu = GameMusicEmu::from_file("assets/test.nsf", sample_rate).unwrap();
+    game_music_emu.start_track(0).unwrap();
 
     let play_f32 = move |output_buffer: &mut [f32], _: &cpal::OutputCallbackInfo| {
-        game_music_emu.play(BUFFER_SIZE, &mut emu_buffer).unwrap();
-        output_buffer.iter_mut().enumerate().for_each(|(i, sample)| {
-            *sample = emu_buffer[i] as f32 / 32768.0;
-        });
+        let len = output_buffer.len();
+        let mut emu_buffer = vec![0i16; len];
+        game_music_emu.play(len, &mut emu_buffer).unwrap();
+        for (sample, &emu_sample) in output_buffer.iter_mut().zip(&emu_buffer) {
+            *sample = emu_sample as f32 / i16::MAX as f32;
+        }
     };
 
     let stream = match config.sample_format() {
         SampleFormat::F32 => device.build_output_stream(&config.config(), play_f32, err_fn),
-        _ => panic!("only implemented for f32")
-    }.unwrap();
+        _ => panic!("only implemented for f32"),
+    }
+    .unwrap();
     stream.play().unwrap();
 
     loop {}


### PR DESCRIPTION
Refactored the audio callback logic in `play_nsf` to ensure the internal GME buffer size precisely matches the required cpal output buffer size, resolving an intermittent `index out of bounds: the len is 1024 but the index is 1024` panic in the audio thread.
The fix primarily ensures stability of the GME-to-cpal buffer transfer.

Fixes #2 