### PR TITLE
Fix: Replace err-derive with thiserror, update error.rs, and resolve …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ ym2612_emu_nuked = []
 ym2612_emu_mame = []
 
 [dependencies]
-err-derive = "0.3"
+thiserror = "1"
 
 [build-dependencies]
 cc = "1.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 /// Contains an error message passed by Game Music Emu
-#[derive(Debug, err_derive::Error)]
-#[error(display = "_0")]
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
 pub struct GmeError(String);
 
 impl GmeError {
@@ -16,12 +16,24 @@ impl GmeError {
 pub(crate) type GmeResult<T> = Result<T, GmeError>;
 
 /// Either an IO error or a GME error
-#[derive(Debug, err_derive::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum GmeOrIoError {
-    #[error(display = "IO error: _0")]
+    #[error("IO error: {0}")]
     IoError(#[source] std::io::Error),
-    #[error(display = "GME error: _0")]
+    #[error("GME error: {0}")]
     Gme(#[source] GmeError),
+}
+
+impl From<std::io::Error> for GmeOrIoError {
+    fn from(err: std::io::Error) -> Self {
+        GmeOrIoError::IoError(err)
+    }
+}
+
+impl From<GmeError> for GmeOrIoError {
+    fn from(err: GmeError) -> Self {
+        GmeOrIoError::Gme(err)
+    }
 }
 
 // pub(crate) type GmeOrIoResult<T> = Result<T, GmeOrIoError>;


### PR DESCRIPTION
…all Rust warnings
This PR replaces the err-derive crate with thiserror for error handling.
The error.rs file is updated to use thiserror and the error types are modernized.
This change removes warnings, improves compatibility, and makes error handling more standard and maintainable.
Fixes #6