### PR TITLE
Add EmuTrackInfo struct and related functionality

### DIFF
--- a/src/emu_track_info.rs
+++ b/src/emu_track_info.rs
@@ -1,0 +1,20 @@
+#[derive(Clone, Default)]
+pub struct EmuTrackInfo {
+    pub length: Option<u32>,
+    pub intro_length: Option<u32>,
+    pub loop_length: Option<u32>,
+    pub play_length: u32,
+    pub system: Option<String>,
+    pub game: Option<String>,
+    pub song: Option<String>,
+    pub author: Option<String>,
+    pub copyright: Option<String>,
+    pub comment: Option<String>,
+    pub dumper: Option<String>,
+}
+
+impl EmuTrackInfo {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub use self::{
     wrapper::GameMusicEmu,
 };
 
+mod emu_track_info;
 mod emu_type;
 mod error;
 mod native;

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,3 +1,4 @@
+use crate::emu_track_info::EmuTrackInfo;
 use crate::emu_type::EmuType;
 use crate::native::EmuHandle;
 use crate::{GmeOrIoError, GmeResult, native};
@@ -68,6 +69,10 @@ impl GameMusicEmu {
     pub fn track_ended(&self) -> bool {
         native::track_ended(&self.handle)
     }
+
+    pub fn track_info(&self, track: u32) -> GmeResult<EmuTrackInfo> {
+        native::track_info(&self.handle, track)
+    }
 }
 
 #[cfg(test)]
@@ -116,5 +121,22 @@ mod tests {
         assert_eq!(Arc::strong_count(&handle.emu), 1);
         let handle = handle.clone();
         assert_eq!(Arc::strong_count(&handle.emu), 2);
+    }
+
+    #[test]
+    fn test_track_info() {
+        let gme = GameMusicEmu::from_file(TEST_NSF_PATH, 44100).unwrap();
+        let info = gme.track_info(0).unwrap();
+        assert_eq!(info.length, None);
+        assert_eq!(info.intro_length, None);
+        assert_eq!(info.loop_length, None);
+        assert_eq!(info.play_length, 150000);
+        assert_eq!(info.system, Some("Nintendo NES".into()));
+        assert_eq!(info.game, Some("Tetris (GB)".into()));
+        assert_eq!(info.song, Some("".into()));
+        assert_eq!(info.author, Some("".into()));
+        assert_eq!(info.copyright, Some("Nintendo".into()));
+        assert_eq!(info.comment, Some("".into()));
+        assert_eq!(info.dumper, Some("".into()));
     }
 }


### PR DESCRIPTION
This PR adds the EmuTrackInfo struct and related functions to the project.
With this change, Rust code can easily access track metadata (such as title, system, game, author, copyright, etc.) in a safe and idiomatic way.
This helps users retrieve and use music track information from the emulator more conveniently.
Fixes #7 